### PR TITLE
Fix app name case

### DIFF
--- a/mobile_client/android/app/src/main/res/values/strings.xml
+++ b/mobile_client/android/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
-    <string name="app_name">Life beacon 360</string>
-    <string name="title_activity_main">Life beacon 360</string>
+    <string name="app_name">Life Beacon 360</string>
+    <string name="title_activity_main">Life Beacon 360</string>
     <string name="package_name">com.github.tiny_giraffes.life_beacon_360</string>
     <string name="custom_url_scheme">com.github.tiny_giraffes.life_beacon_360</string>
 </resources>

--- a/mobile_client/capacitor.config.ts
+++ b/mobile_client/capacitor.config.ts
@@ -2,7 +2,7 @@ import type { CapacitorConfig } from "@capacitor/cli";
 
 const config: CapacitorConfig = {
   appId: "com.github.tiny_giraffes.life_beacon_360",
-  appName: "Life beacon 360",
+  appName: "Life Beacon 360",
   webDir: "dist",
   plugins: {
     BackgroundGeolocation: {

--- a/mobile_client/index.html
+++ b/mobile_client/index.html
@@ -22,7 +22,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Life beacon 360</title>
+    <title>Life Beacon 360</title>
   </head>
   <body>
     <div id="app"></div>


### PR DESCRIPTION
## Summary
- fix capitalization of app name across files

## Testing
- `npm run build-only`
- `./gradlew assembleDebug` *(fails: Could not read script `capacitor-cordova-android-plugins/cordova.variables.gradle`)*

------
https://chatgpt.com/codex/tasks/task_e_684281ae9ac08321886ae21a18b668fd